### PR TITLE
[#146]: Fix INFO flag bug, for inconsistent headers.

### DIFF
--- a/tests/test_reader_read_file.py
+++ b/tests/test_reader_read_file.py
@@ -2,6 +2,7 @@
 """Reading of VCF files from plain and bgzip-ed files
 """
 
+import io
 import os
 
 from vcfpy import reader
@@ -49,3 +50,19 @@ def test_read_text_no_samples():
     for record in r:
         records.append(record)
     assert len(records) == 5
+
+
+def test_read_info_flag():
+    """Test reading INFO field flag with inconsistent header metadata."""
+    # In the INFO field, `MH` is a flag but the header specifies it as a string.
+    string_buffer = io.StringIO(r"""##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=MH,Number=1,Type=String,Description="Microhomology">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	FOO	BAR
+1	4798729	.	CT	C	621	PASS	MH	GT	0/0:25	0/1:64
+""")
+
+    # Verify that no TypeError is raised.
+    with reader.Reader.from_stream(string_buffer) as r:
+        line = next(r)
+        assert line.INFO['MH']

--- a/vcfpy/parser.py
+++ b/vcfpy/parser.py
@@ -260,7 +260,7 @@ def parse_field_value(field_info, value):
     """
     if field_info.id == "FT":
         return [x for x in value.split(";") if x != "."]
-    elif field_info.type == "Flag":
+    elif isinstance(value, bool) or field_info.type == "Flag":
         return True
     elif field_info.number == 1:
         return convert_field_value(field_info.type, value)


### PR DESCRIPTION
This pull requests fixes Issue [#146].
**Problem**:  a vcf can not be parsed when a flag was given to the INFO column with a definition that is inconsistent with the header.
**Solution**: The flag definition in the INFO column takes precedence over the definition in the header.

Contains unit test with a minimal example.