### PR TITLE
fix: escaped equal sign in INFO fields

### DIFF
--- a/vcfpy/record.py
+++ b/vcfpy/record.py
@@ -35,7 +35,7 @@ HET = 1
 HOM_ALT = 2
 
 #: Characters reserved in VCF, have to be escaped in INFO fields
-RESERVED_CHARS = {"INFO": ";%,\r\n\t", "FORMAT": ":=%,\r\n\t"}
+RESERVED_CHARS = {"INFO": ";=%,\r\n\t", "FORMAT": ":=%,\r\n\t"}
 #: Mapping for escaping reserved characters
 ESCAPE_MAPPING = [
     ("%", "%25"),


### PR DESCRIPTION
The change made escapes equal sign (`=`) in INFO fields.

However, the column characters `:` are also escaped on output, as recommended by the [vcf 4.3 format](https://samtools.github.io/hts-specs/VCFv4.3.pdf).

It is unclear if the column character `:` _should_ be escaped in INFO fields of vcf files in [4.2 format](https://samtools.github.io/hts-specs/VCFv4.2.pdf). The 4.2 format documentation seems to suggest that only whitespace, semicolons, and equals-sign are forbidden (and therefore should be escaped).

In its current incarnation, `vcfpy` escapes of column characters regardless of the vcf version. It is unclear to me what is the best practical approach for `vcfpy`, as I am unsure how strictly commonly used software is following the format.