### PR TITLE
fix: return type of Reader.__next__

### DIFF
--- a/src/vcfpy/reader.py
+++ b/src/vcfpy/reader.py
@@ -191,7 +191,11 @@ class Reader:
         :raises: ``StopException`` if at end
         """
         if self.tabix_iter:
-            return self.parser.parse_line(str(next(self.tabix_iter)))
+            result = self.parser.parse_line(str(next(self.tabix_iter)))
+            if result is None:
+                raise StopIteration()
+            else:
+                return result
         else:
             result = self.parser.parse_next_record()
             if result is None:

--- a/src/vcfpy/reader.py
+++ b/src/vcfpy/reader.py
@@ -192,13 +192,10 @@ class Reader:
         """
         if self.tabix_iter:
             result = self.parser.parse_line(str(next(self.tabix_iter)))
-            if result is None:
-                raise StopIteration()
-            else:
-                return result
         else:
             result = self.parser.parse_next_record()
-            if result is None:
-                raise StopIteration()
-            else:
-                return result
+
+        if result is None:
+            raise StopIteration()
+
+        return result

--- a/uv.lock
+++ b/uv.lock
@@ -1316,7 +1316,7 @@ wheels = [
 
 [[package]]
 name = "vcfpy"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1316,7 +1316,7 @@ wheels = [
 
 [[package]]
 name = "vcfpy"
-version = "0.14.2"
+version = "0.14.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
The return type of `next(vcfpy.Reader("foo.vcf"))` is currently `Record | None`. I believe it should be `Record`.


```python
# foo.py
import vcfpy
for rec in vcfpy.Reader("foo.vcf"):
    reveal_type(rec)
```

Running `uv run -- pyright foo.py`:

```
Type of "rec" is "Record | None"  # at a9353cd
Type of "rec" is "Record"         # this MR
```


Thank you for the recent type-hint fixes, by the way. It nudged me to make this PR.