### PR TITLE
fix: Preserve src-layout in source distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,6 @@ run = "hatch build"
 packages = ["src/vcfpy"]
 
 [tool.hatch.build.targets.sdist]
-packages = ["src/vcfpy"]
 exclude = [
   "/.editorconfig",
   "/Makefile",
@@ -181,3 +180,4 @@ exclude = [
   "/.gitignore",
   "/tests",
 ]
+only-include = ["src"]


### PR DESCRIPTION
The sdist build was flattening src/vcfpy/ to vcfpy/ but keeping the pyproject.toml reference to 'src/vcfpy', causing wheel builds from the tarball to create empty 3KB wheels instead of proper 43KB wheels.

This broke:
- Conda/bioconda builds (workaround in https://github.com/bioconda/bioconda-recipes/pull/60734)
- pip install --no-binary :all:
- Any downstream packager building from source

Fix: Use only-include=["src"] to preserve directory structure in sdist, ensuring builds from tarball work correctly.